### PR TITLE
feat: 식당리뷰 순환참조 문제 해결, 프론트 요청으로 인한 수정

### DIFF
--- a/src/main/java/com/app/vple/domain/PlanTravel.java
+++ b/src/main/java/com/app/vple/domain/PlanTravel.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
+import java.time.LocalTime;
 
 @Entity
 @Getter
@@ -42,4 +43,7 @@ public class PlanTravel {
 
     @Column(nullable = false)
     private int day;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
 }

--- a/src/main/java/com/app/vple/domain/dto/MyPlansDto.java
+++ b/src/main/java/com/app/vple/domain/dto/MyPlansDto.java
@@ -1,7 +1,11 @@
 package com.app.vple.domain.dto;
 
 import com.app.vple.domain.Plan;
+import com.app.vple.domain.PlanTravel;
 import lombok.Data;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Data
 public class MyPlansDto {
@@ -10,8 +14,34 @@ public class MyPlansDto {
 
     private String title;
 
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private String image1;
+
+    private String image2;
+
+    public String imageEmpty(List<PlanTravel> planTravels, int idx) {
+        if (planTravels.size() <= idx) {
+            return null;
+        }
+        else {
+            if (planTravels.get(idx).getImage() == null) {
+                return null;
+            }
+            else {
+                return planTravels.get(idx).getImage();
+            }
+        }
+    }
+
     public MyPlansDto(Plan entity) {
         this.id = entity.getId();
         this.title = entity.getTitle();
+        this.startDate = entity.getStartDate();
+        this.endDate = entity.getEndDate();
+        this.image1 = imageEmpty(entity.getPlanTravels(), 0);
+        this.image2 = imageEmpty(entity.getPlanTravels(), 1);
     }
 }

--- a/src/main/java/com/app/vple/domain/dto/PlanDetailDto.java
+++ b/src/main/java/com/app/vple/domain/dto/PlanDetailDto.java
@@ -1,9 +1,11 @@
 package com.app.vple.domain.dto;
 
 import com.app.vple.domain.Plan;
+import com.app.vple.domain.PlanTravel;
 import lombok.Data;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,6 +36,8 @@ public class PlanDetailDto {
         this.city = entity.getCity();
         this.planTravels = entity.getPlanTravels()
                 .stream()
+                .sorted(Comparator.comparing(PlanTravel::getDay)
+                .thenComparing(PlanTravel::getStartTime))
                 .map(PlanTravelDto::new)
                 .collect(Collectors.toList());
         this.isOpened = entity.isOpened();

--- a/src/main/java/com/app/vple/domain/dto/PlanTravelAddDto.java
+++ b/src/main/java/com/app/vple/domain/dto/PlanTravelAddDto.java
@@ -2,10 +2,14 @@ package com.app.vple.domain.dto;
 
 import com.app.vple.domain.Plan;
 import com.app.vple.domain.PlanTravel;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import java.time.LocalTime;
 
 @Data
 public class PlanTravelAddDto {
@@ -29,6 +33,11 @@ public class PlanTravelAddDto {
     @NotNull(message = "몇일째의 여행지인지가 필요합니다.")
     private int day;
 
+    @NotNull(message = "해당 장소의 여행 시작 시간을 적어주세요.")
+    @JsonDeserialize(using = LocalTimeDeserializer.class)
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+    private LocalTime startTime;
+
     public PlanTravel toEntity(Plan plan) {
         return PlanTravel.builder()
                 .name(name)
@@ -37,6 +46,7 @@ public class PlanTravelAddDto {
                 .latitude(latitude)
                 .image(image)
                 .day(day)
+                .startTime(startTime)
                 .plan(plan)
                 .build();
     }

--- a/src/main/java/com/app/vple/domain/dto/PlanTravelDto.java
+++ b/src/main/java/com/app/vple/domain/dto/PlanTravelDto.java
@@ -3,6 +3,8 @@ package com.app.vple.domain.dto;
 import com.app.vple.domain.PlanTravel;
 import lombok.Data;
 
+import java.time.LocalTime;
+
 @Data
 public class PlanTravelDto {
 
@@ -14,10 +16,13 @@ public class PlanTravelDto {
 
     private int day;
 
+    private LocalTime startTime;
+
     public PlanTravelDto(PlanTravel entity) {
         this.id = entity.getId();
         this.name = entity.getName();
         this.address = entity.getAddress();
         this.day = entity.getDay();
+        this.startTime = entity.getStartTime();
     }
 }

--- a/src/main/java/com/app/vple/domain/dto/RestaurantReviewDto.java
+++ b/src/main/java/com/app/vple/domain/dto/RestaurantReviewDto.java
@@ -9,7 +9,7 @@ public class RestaurantReviewDto {
 
     private Long id;
 
-    private User user;
+    private String nickname;
 
     private String title;
 
@@ -19,10 +19,10 @@ public class RestaurantReviewDto {
 
 
     public RestaurantReviewDto(RestaurantReview entity) {
-        id = entity.getId();
-        user = entity.getUser();
-        title = entity.getTitle();
-        text = entity.getText();
-        image = entity.getImage();
+        this.id = entity.getId();
+        this.nickname = entity.getUser().getNickname();
+        this.title = entity.getTitle();
+        this.text = entity.getText();
+        this.image = entity.getImage();
     }
 }


### PR DESCRIPTION
RestaurantReviewDto에서 User 값 반환으로 인한 순환참조 문제 발생
-> User 값 반환 대신 nickname 값 반환으로 변경 하여 순환참조 문제 해결

- 플랜여행지 데이터에 여행 시작 데이터 startTime으로 추가
- 플랜 상세보기에서 여행지목록 day와 startTime 순으로 정렬해서 반환
- 플랜 생성시 내 플랜 목록들의 반환 데이터를
    - 여행 시작,종료 데이터를 추가로 반환하도록 수정
    - 플랜 여행지 사진 데이터 상위 항목 2개 반환하도록 수정