### PR TITLE
feat: 추천 플래너 조회 기능 유저 권한 없이 사용가능 및 공개여부 반영되도록 변경

### DIFF
--- a/src/main/java/com/app/vple/controller/PlanController.java
+++ b/src/main/java/com/app/vple/controller/PlanController.java
@@ -20,14 +20,13 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth/plan")
 public class PlanController {
 
     private final UserService userService;
 
     private final PlanService planService;
 
-    @GetMapping
+    @GetMapping("/auth/plan")
     public ResponseEntity<?> planList(HttpServletRequest request) {
         try {
             User loginUser = userService.getUser(request);
@@ -38,7 +37,7 @@ public class PlanController {
         }
     }
 
-    @GetMapping("/like")
+    @GetMapping("/api/plan/like")
     public ResponseEntity<?> planLikeList(
             @PageableDefault(size = 20, sort="likesCount", direction = Sort.Direction.DESC) Pageable pageable) {
         try {
@@ -49,7 +48,7 @@ public class PlanController {
         }
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/auth/plan/{id}")
     public ResponseEntity<?> planDetails(@PathVariable Long id) {
         try {
             PlanDetailDto plan = planService.findPlanDetails(id);
@@ -59,7 +58,7 @@ public class PlanController {
         }
     }
 
-    @PostMapping
+    @PostMapping("/auth/plan")
     public ResponseEntity<?> planAdd(HttpServletRequest request, @Validated @RequestBody PlanCreateDto planCreateDto) {
         try {
             User loginUser = userService.getUser(request);
@@ -71,7 +70,7 @@ public class PlanController {
         }
     }
 
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/auth/plan/{id}")
     public ResponseEntity<?> planRemove(@PathVariable Long id) {
         try {
             String title = planService.removePlan(id);
@@ -81,7 +80,7 @@ public class PlanController {
         }
     }
 
-    @PatchMapping("/{id}")
+    @PatchMapping("/auth/plan/{id}")
     public ResponseEntity<?> planModify(@PathVariable Long id,
                                         @Validated @RequestBody PlanUpdateDto planUpdateDto) {
         try {
@@ -92,7 +91,7 @@ public class PlanController {
         }
     }
 
-    @PatchMapping("/like/{id}")
+    @PatchMapping("/auth/plan/like/{id}")
     public ResponseEntity<?> planLikeAdd(HttpServletRequest request, @PathVariable Long id) {
         try {
             User loginUser = userService.getUser(request);

--- a/src/main/java/com/app/vple/repository/PlanRepository.java
+++ b/src/main/java/com/app/vple/repository/PlanRepository.java
@@ -2,6 +2,8 @@ package com.app.vple.repository;
 
 import com.app.vple.domain.Plan;
 import com.app.vple.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,4 +11,6 @@ import java.util.List;
 public interface PlanRepository extends JpaRepository<Plan, Long> {
 
     List<Plan> findPlanByUser(User user);
+
+    Page<Plan> findPlanByIsOpenedTrue(Pageable pageable);
 }

--- a/src/main/java/com/app/vple/service/PlanService.java
+++ b/src/main/java/com/app/vple/service/PlanService.java
@@ -41,7 +41,7 @@ public class PlanService {
     }
 
     public Page<PlanListDto> findLikeList(Pageable pageable) {
-        Page<Plan> plans = planRepository.findAll(pageable);
+        Page<Plan> plans = planRepository.findPlanByIsOpenedTrue(pageable);
 
         return plans.map(PlanListDto::new);
     }


### PR DESCRIPTION
- 추천 플래너 비로그인 시에도 조회 가능하도록 변경
- 공개여부 체크 된 것만 추천 플래너 목록에 보이도록 변경