### PR TITLE
feat: 플랜 여행지 필드에서 address 제거

### DIFF
--- a/src/main/java/com/app/vple/domain/PlanTravel.java
+++ b/src/main/java/com/app/vple/domain/PlanTravel.java
@@ -31,9 +31,6 @@ public class PlanTravel {
     private String name;
 
     @Column(nullable = false)
-    private String address;
-
-    @Column(nullable = false)
     private String longitude;
 
     @Column(nullable = false)

--- a/src/main/java/com/app/vple/domain/PlanTravel.java
+++ b/src/main/java/com/app/vple/domain/PlanTravel.java
@@ -30,6 +30,9 @@ public class PlanTravel {
     @Column(nullable = false)
     private String name;
 
+    @Column
+    private String address;
+
     @Column(nullable = false)
     private String longitude;
 

--- a/src/main/java/com/app/vple/domain/dto/PlanTravelAddDto.java
+++ b/src/main/java/com/app/vple/domain/dto/PlanTravelAddDto.java
@@ -19,9 +19,6 @@ public class PlanTravelAddDto {
 
     private Long planId;
 
-    @NotNull(message = "주소가 필요합니다.")
-    private String address;
-
     @NotNull(message = "경도가 필요합니다.")
     private String longitude;
 
@@ -41,7 +38,6 @@ public class PlanTravelAddDto {
     public PlanTravel toEntity(Plan plan) {
         return PlanTravel.builder()
                 .name(name)
-                .address(address)
                 .longitude(longitude)
                 .latitude(latitude)
                 .image(image)

--- a/src/main/java/com/app/vple/domain/dto/PlanTravelDetailDto.java
+++ b/src/main/java/com/app/vple/domain/dto/PlanTravelDetailDto.java
@@ -8,8 +8,6 @@ public class PlanTravelDetailDto {
 
     private String name;
 
-    private String address;
-
     private String longitude;
 
     private String latitude;
@@ -20,7 +18,6 @@ public class PlanTravelDetailDto {
 
     public PlanTravelDetailDto(PlanTravel entity) {
         this.name = entity.getName();
-        this.address = entity.getAddress();
         this.longitude = entity.getLongitude();
         this.latitude = entity.getLatitude();
         this.image = entity.getImage();

--- a/src/main/java/com/app/vple/domain/dto/PlanTravelDto.java
+++ b/src/main/java/com/app/vple/domain/dto/PlanTravelDto.java
@@ -12,8 +12,6 @@ public class PlanTravelDto {
 
     private String name;
 
-    private String address;
-
     private int day;
 
     private LocalTime startTime;
@@ -21,7 +19,6 @@ public class PlanTravelDto {
     public PlanTravelDto(PlanTravel entity) {
         this.id = entity.getId();
         this.name = entity.getName();
-        this.address = entity.getAddress();
         this.day = entity.getDay();
         this.startTime = entity.getStartTime();
     }


### PR DESCRIPTION
플랜 여행지 테이블에서 사용되지 않는 address 필드를 제거함.
-> 도메인 필드값 삭제로 데이터베이스 컬럼 불일치 발생 예상
-> 도메인 필드는 남겨두고 Dto에서 address 제거