### PR TITLE
fix: 참조 관계 때문에 delete 되지 않는 현상 수정

### DIFF
--- a/src/main/java/com/app/vple/domain/CheckDuplicatedPlanLike.java
+++ b/src/main/java/com/app/vple/domain/CheckDuplicatedPlanLike.java
@@ -1,6 +1,8 @@
 package com.app.vple.domain;
 
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -15,10 +17,12 @@ public class CheckDuplicatedPlanLike {
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "plan_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Plan plan;
 
     public CheckDuplicatedPlanLike(User user, Plan plan) {


### PR DESCRIPTION
플래너 좋아요 기능에서 좋아요를 중복으로 할 수 없도록 구현한 checkDuplicatedPlanLike 클래스에서 
좋아요를 누른 플래너를 참조하고 있는 경우 삭제되지 않는 현상을 발견하고 해결하였다.

다른 매핑에서 처럼 @OnDelete(action = OnDeleteAction.CASCADE)를 적용해 주었다.