### PR TITLE
fix: 참조 문제로 좋아요가 눌린 플랜 삭제 되지 않는 문제 해결

### DIFF
--- a/src/main/java/com/app/vple/repository/CheckDuplicatedPlanLikeRepository.java
+++ b/src/main/java/com/app/vple/repository/CheckDuplicatedPlanLikeRepository.java
@@ -13,4 +13,6 @@ public interface CheckDuplicatedPlanLikeRepository extends JpaRepository<CheckDu
     Optional<CheckDuplicatedPlanLike> findByUserAndPlan(User user, Plan plan);
 
     List<CheckDuplicatedPlanLike> findByUser(User user);
+
+    CheckDuplicatedPlanLike findByPlan(Plan plan);
 }

--- a/src/main/java/com/app/vple/service/PlanService.java
+++ b/src/main/java/com/app/vple/service/PlanService.java
@@ -70,6 +70,11 @@ public class PlanService {
                 () -> new NoSuchElementException("해당 플랜이 존재하지 않습니다.")
         );
 
+        CheckDuplicatedPlanLike like = checkDuplicatedPlanLikeRepository.findByPlan(plan);
+        if (like != null) {
+            checkDuplicatedPlanLikeRepository.delete(like);
+        }
+
         planRepository.delete(plan);
 
         return plan.getTitle();

--- a/src/test/java/com/app/vple/service/PlanServiceTest.java
+++ b/src/test/java/com/app/vple/service/PlanServiceTest.java
@@ -1,0 +1,57 @@
+package com.app.vple.service;
+
+import com.app.vple.domain.Plan;
+import com.app.vple.domain.dto.PlanCreateDto;
+import com.app.vple.domain.dto.PlanDetailDto;
+import com.app.vple.repository.PlanRepository;
+import com.app.vple.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class PlanServiceTest {
+
+    @Autowired
+    private PlanService planService;
+
+    @Autowired
+    private PlanRepository planRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private Plan plan;
+
+    private Long planId;
+
+    @Test
+    void 플랜_생성_테스트() {
+        PlanCreateDto planCreateDto = new PlanCreateDto();
+
+        planCreateDto.setTitle("강릉 여행");
+        planCreateDto.setCity("강릉");
+        planCreateDto.setDistrict("속초");
+        planCreateDto.setStartDate(LocalDate.of(2023,07,01));
+        planCreateDto.setEndDate(LocalDate.of(2023,07,07));
+        planCreateDto.setPeopleNum(4);
+
+        planId = planService.addPlan(planCreateDto, "kimsh2948@kakao.com");
+        plan = planRepository.findById(planId).get();
+
+        assertEquals(planCreateDto.getTitle(), plan.getTitle());
+    }
+
+    @Test
+    void 플랜_삭제_테스트() {
+
+    }
+}


### PR DESCRIPTION
- 좋아요 중복 체크 테이블이 User 테이블까지 참조하고 있는 문제로 Plan 삭제 시 JPA의 ondelete 옵션이 제대로 먹히지 않음.
- jpa 옵션으로 해결해 보려했지만 실패. Plan 삭제시 좋아요가 눌려있는지 체크하고 먼저 삭제후 플랜 삭제 하도록 변경